### PR TITLE
added flag for disable all calls (InkEnable fix issue)

### DIFF
--- a/src/M5CoreInk.cpp
+++ b/src/M5CoreInk.cpp
@@ -10,6 +10,9 @@ M5CoreInk::~M5CoreInk()
 
 int M5CoreInk::begin(bool InkEnable, bool wireEnable, bool SpeakerEnable)
 {
+
+    _inkEnable = InkEnable;
+
     pinMode(POWER_HOLD_PIN, OUTPUT);
     digitalWrite(POWER_HOLD_PIN, HIGH); // Hold power
 
@@ -62,7 +65,7 @@ void M5CoreInk::shutdown()
 }
 int M5CoreInk::shutdown(int seconds)
 {
-    M5Ink.deepSleep();
+    if (_inkEnable) M5Ink.deepSleep();
     rtc.clearIRQ();
     rtc.SetAlarmIRQ(seconds);
     delay(10);
@@ -71,7 +74,7 @@ int M5CoreInk::shutdown(int seconds)
 }
 int M5CoreInk::shutdown(const RTC_TimeTypeDef &RTC_TimeStruct)
 {
-    M5Ink.deepSleep();
+    if (_inkEnable) M5Ink.deepSleep();
     rtc.clearIRQ();
     rtc.SetAlarmIRQ(RTC_TimeStruct);
     delay(10);
@@ -80,7 +83,7 @@ int M5CoreInk::shutdown(const RTC_TimeTypeDef &RTC_TimeStruct)
 }
 int M5CoreInk::shutdown(const RTC_DateTypeDef &RTC_DateStruct, const RTC_TimeTypeDef &RTC_TimeStruct)
 {
-    M5Ink.deepSleep();
+    if (_inkEnable) M5Ink.deepSleep();
     rtc.clearIRQ();
     rtc.SetAlarmIRQ(RTC_DateStruct,RTC_TimeStruct);
     delay(10);

--- a/src/M5CoreInk.h
+++ b/src/M5CoreInk.h
@@ -17,6 +17,7 @@ class M5CoreInk
 private:
     /* data */
     // WFT0154CZB3
+    bool _inkEnable;
 public:
     M5CoreInk(/* args */);
     ~M5CoreInk();


### PR DESCRIPTION
We have a issue, when I try to use different Gfx library for eInk handling via SPI, the M5-CoreInk library don't disable completely the SPI calls, in this little pull request I disabled this calls (`deepSleep` calls) when the **inkEnable** is false.